### PR TITLE
Better support for react-native

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,13 @@
 'use strict';
 
-import _Promise from 'promiz';
 if (!global.Promise) {
-  global.Promise = _Promise;
+  global.Promise = require('promiz');
 }
 
 let AbortablePromise = require('dodgy');
 
-import _fetch from 'isomorphic-fetch';
 if (!global.fetch) {
-  global.fetch = _fetch;
+  global.fetch = require('isomorphic-fetch');
 }
 
 // Query string parser and stringifier -- fetch does not support any query string


### PR DESCRIPTION
Moves the `Promise` and `fetch` shim imports into the if block. Uses `require` since `import` is hoisted to top of module.

This ensures that environments that cannot imoprt `isomorphic-fetch` or `promiz` can still import papi.js